### PR TITLE
Fix send event method name

### DIFF
--- a/lib/raven/transports/fluentd.rb
+++ b/lib/raven/transports/fluentd.rb
@@ -9,7 +9,7 @@ module Raven
   module Transports
     class Fluentd < Transport
 
-      def send(auth_header, data, options = {})
+      def send_event(auth_header, data, options = {})
         conn.post('error', auth_header: auth_header, data: data, options: options, project_id: configuration.project_id)
       end
 

--- a/raven-transports-fluentd.gemspec
+++ b/raven-transports-fluentd.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
 
   spec.add_dependency "fluent-logger"
-  spec.add_dependency "sentry-raven", ">= 0.10.1"
+  spec.add_dependency "sentry-raven", ">= 0.13.2"
 end


### PR DESCRIPTION
Fix the name of the method to send the event because `Transport#send` has been changed to `#send_event` at [v0.13.2](https://github.com/getsentry/raven-ruby/blob/0.13.2/lib/raven/transports.rb).

Please review it. :bow: 
