### PR TITLE
Support sentry-raven >= 2.2.0

### DIFF
--- a/lib/raven/transports/fluentd.rb
+++ b/lib/raven/transports/fluentd.rb
@@ -10,25 +10,22 @@ module Raven
     class Fluentd < Transport
 
       def send_event(auth_header, data, options = {})
+        unless configuration.sending_allowed?
+          configuration.logger.debug("Event not sent: #{configuration.error_messages}")
+        end
+
         conn.post('error', auth_header: auth_header, data: data, options: options, project_id: configuration.project_id)
       end
 
       private
 
       def conn
-        verify_configuration
-
         @conn ||= begin
           uri = URI.parse(self.configuration.server)
 
           ::Fluent::Logger::FluentLogger.new('sentry', host: uri.host, port: uri.port)
         end
       end
-
-      def verify_configuration
-        super
-      end
-
     end
   end
 end

--- a/raven-transports-fluentd.gemspec
+++ b/raven-transports-fluentd.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
 
   spec.add_dependency "fluent-logger"
-  spec.add_dependency "sentry-raven", ">= 0.13.2"
+  spec.add_dependency "sentry-raven", ">= 2.2.0"
 end


### PR DESCRIPTION
`Raven::Transports#verify_configuration` is dropped in sentry-raven 2.2.0.
https://github.com/getsentry/raven-ruby/commit/fab3d6b21c875c160ba15b2858c36414c720569d

This patch let `Raven::Transports::Fluentd` follow implementation of `Raven::Transports::HTTP`.
See https://github.com/getsentry/raven-ruby/blob/v2.2.0/lib/raven/transports/http.rb#L18-L20.

Please review @cookpad/dev-infra 