### PR TITLE
Support raven-sentry 2.7.0

### DIFF
--- a/lib/raven/transports/fluentd.rb
+++ b/lib/raven/transports/fluentd.rb
@@ -1,7 +1,7 @@
 require 'fluent-logger'
 
 require 'raven/transports'
-require 'raven/error'
+require 'raven/base'
 
 require 'uri'
 

--- a/raven-transports-fluentd.gemspec
+++ b/raven-transports-fluentd.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
 
   spec.add_dependency "fluent-logger"
-  spec.add_dependency "sentry-raven", ">= 2.2.0"
+  spec.add_dependency "sentry-raven", ">= 2.7.0"
 end


### PR DESCRIPTION
 To follow a raven-ruby 2.7.0 change, this patch changes `require`d path(`lib/sentry/error.rb`) to `lib/sentry/base.rb`.

In raven-ruby 2.7.0, `lib/sentry/error.rb` is deleted and its code is moved to `lib/sentry/base.rb`. 
https://github.com/getsentry/raven-ruby/pull/749/commits/4919414ee773dd9de45ae96f87ccaa0eedc8cf15

@cookpad/dev-infra Review please


