### PR TITLE
Update rack because of vulnerability

### DIFF
--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.10)


### PR DESCRIPTION
rack `< 1.6.11` has a possible XSS vulnerability.
https://nvd.nist.gov/vuln/detail/CVE-2018-16471