### PR TITLE
Allow out_raven to be used with multiple workers

### DIFF
--- a/lib/fluent/plugin/out_raven.rb
+++ b/lib/fluent/plugin/out_raven.rb
@@ -27,6 +27,10 @@ module Fluent
       end
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def start
       super
     end


### PR DESCRIPTION
```
$ cat fluent.conf
<system>
  workers 2
</system>

<match *>
  @type raven
  server foo
  raven_log_path foo.log
</match>
```

Before:

```
$ bundle exec fluentd -c fluent.conf
2019-03-18 16:32:05 +0000 [info]: parsing config file is succeeded path="fluent.conf"
2019-03-18 16:32:05 +0000 [error]: config error file="fluent.conf" error_class=Fluent::ConfigError error="Plugin 'raven' does not support multi workers configuration (Fluent::RavenOutput)"
```

After:

```
$ bundle exec fluentd -c fluent.conf
2019-03-18 16:32:48 +0000 [info]: parsing config file is succeeded path="fluent.conf"
2019-03-18 16:32:48 +0000 [info]: using configuration file: <ROOT>
...
```

I believe out_raven is able to work with multiple workers without any change.