### PR TITLE
Store log of Raven via Fluent::Log

### DIFF
--- a/lib/fluent/plugin/out_raven.rb
+++ b/lib/fluent/plugin/out_raven.rb
@@ -8,7 +8,7 @@ module Fluent
     config_param :ssl_verification, :bool, default: false
     config_param :timeout, :integer, default: 1
     config_param :open_timeout, :integer, default: 1
-    config_param :raven_log_path, :string
+    config_param :raven_log_path, :string, default: nil
     config_param :raven_log_level, :string, default: 'info'
 
     def configure(conf)
@@ -23,7 +23,11 @@ module Fluent
       @base_configuration.open_timeout = conf['open_timeout']
 
       Raven.configure do |config|
-        config.logger = Logger.new(conf['raven_log_path'], log_level(conf['raven_log_level']))
+        config.logger = if conf['raven_log_path'].nil?
+                          log
+                        else
+                          Logger.new(conf['raven_log_path'], log_level(conf['raven_log_level']))
+                        end
       end
     end
 

--- a/lib/fluent/plugin/out_raven.rb
+++ b/lib/fluent/plugin/out_raven.rb
@@ -22,6 +22,10 @@ module Fluent
       @base_configuration.timeout = conf['timeout']
       @base_configuration.open_timeout = conf['open_timeout']
 
+      if conf['raven_log_path'].nil?
+        log.warn("`raven_log_level` is meaningless when `raven_log_path` isn't set")
+      end
+
       Raven.configure do |config|
         config.logger = if conf['raven_log_path'].nil?
                           log


### PR DESCRIPTION
When set raven_log_path param, Logger open new file many and many a
time.

```console
$ ls /tmp/sentry8-raven.log.20190819* | head -5
/tmp/sentry8-raven.log.20190819
/tmp/sentry8-raven.log.20190819.1
/tmp/sentry8-raven.log.20190819.10
/tmp/sentry8-raven.log.20190819.100
/tmp/sentry8-raven.log.20190819.11
...
```

I suggest to use Fluent::Log instead of Logger.new.
This store logs to the same as `fluentd -o /path/to/log`.

```
2019-08-19 11:02:04 +0000 [info]: parsing config file is succeeded path="sentry.conf"
2019-08-19 11:02:04 +0000 [info]: [sentry8_error] Raven 2.11.0 configured not to capture errors: DSN not set
2019-08-19 11:02:04 +0000 [info]: using configuration file: <ROOT>
  ...snip...
2019-08-19 11:02:04 +0000 [info]: starting fluentd-1.6.3 pid=1 ruby="2.6.3"
2019-08-19 11:02:04 +0000 [info]: spawn command to main:  cmdline=["/usr/local/bin/ruby", "-Eascii-8bit:ascii-8bit", "/usr/local/bundle/bin/fluentd", "-c", "sentry.conf", "--under-supervisor"]
2019-08-19 11:02:04 +0000 [info]: gem 'fluentd' version '1.6.3'
2019-08-19 11:02:04 +0000 [info]: adding match pattern="sentry.error" type="raven"
2019-08-19 11:02:04 +0000 [info]: #0 [sentry8_error] Raven 2.11.0 configured not to capture errors: DSN not set
...snip...
```

To keep backward-compatibility, this change is enabled only if
raven_log_path is nil. (Because it occurs error in previous versions if
so, it not affect previous settings.)